### PR TITLE
Anchor primary color and frameborder fix

### DIFF
--- a/pages/detail/_pid.vue
+++ b/pages/detail/_pid.vue
@@ -135,7 +135,7 @@
                       : objectInfo.cmodel === 'Container' ? 'height: 300px; width: 100%; border: 0px;' : 'height: 500px; width: 100%; border: 0px;'
                   "
                   scrolling="no"
-                  border="0"
+                  frameborder="0"
                   >Content</iframe
                 >
                 <a
@@ -205,7 +205,7 @@
                       : 'height: 500px; width: 100%; border: 0px;'
                   "
                   scrolling="no"
-                  border="0"
+                  frameborder="0"
                   >Content</iframe
                 >
                 <v-card-text class="ma-2">
@@ -527,7 +527,6 @@
                               objectInfo.pid +
                               '.tif/full/pct:50/0/default.jpg'
                             "
-                            primary
                             >{{ $t("View scaled to 50%") }}</a
                           >
                         </v-row>
@@ -540,7 +539,6 @@
                               objectInfo.pid +
                               '.tif/full/pct:25/0/default.jpg'
                             "
-                            primary
                             >{{ $t("View scaled to 25%") }}</a
                           >
                         </v-row>
@@ -561,7 +559,6 @@
                             objectInfo.pid +
                             '/diss/Content/downloadwebversion'
                           "
-                          primary
                           >{{ $t("Download web-optimized version") }}</a
                         >
                       </v-row>


### PR DESCRIPTION
Anchor primary color is already defined by Vuetify (via Nuxt configuration).

Apply `frameborder` attribute to iframe for consistency as `border` attribute doesn't exist (cf. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe). Actually, `frameborder` attribute should be removed (deprecated attribute) and applied via CSS only.